### PR TITLE
Include test environment creation in try-catch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,12 +51,12 @@ podTemplate(label: pod.label,
                             pwsh -command "New-AzResourceGroup -Name '$ciRg' -Location 'North Europe' -Tag @{subproject='2026956'; Description='Continuous Integration'}"
                         """
                     }
-                    stage('Create test environment'){
-                        sh """
-                            pwsh -command "New-AzResourceGroupDeployment -Name azure-subscription-ci -TemplateFile deployment/azuredeploy.json -ResourceGroupName $ciRg -appName $ciAppName -environment $environment -slackChannel 'mock_mock' -slackBearerToken (ConvertTo-SecureString -String 'mocktoken' -AsPlainText -Force)"
-                        """
-                    }
                     try {
+                        stage('Create test environment'){
+                            sh """
+                                pwsh -command "New-AzResourceGroupDeployment -Name azure-subscription-ci -TemplateFile deployment/azuredeploy.json -ResourceGroupName $ciRg -appName $ciAppName -environment $environment -slackChannel 'mock_mock' -slackBearerToken (ConvertTo-SecureString -String 'mocktoken' -AsPlainText -Force)"
+                            """
+                        }
                         stage('Publish to test environment') {
                             sh """
                                 pwsh -command "Publish-AzWebApp -ResourceGroupName $ciRg -Name $ciAppName -ArchivePath $zipName -Force"


### PR DESCRIPTION
If test environment creation fails the resource group might be left behind. This pull requests makes it so that if that step fails, the created resource group is still deleted.