### PR TITLE
Use begin delete so we don't wait for possibly long running operation

### DIFF
--- a/src/Pinja.AzureSubscriptionCleaner.AzureFunctions.Tests/SubscriptionCleanerTests.cs
+++ b/src/Pinja.AzureSubscriptionCleaner.AzureFunctions.Tests/SubscriptionCleanerTests.cs
@@ -99,7 +99,7 @@ namespace Pinja.AzureSubscriptionCleaner.AzureFunctions.Tests
 
             await _cleaner.DeleteIfNotLocked(ExpectedGroup);
 
-            await _mockAzure.ResourceGroups.DidNotReceive().DeleteByNameAsync(Arg.Any<string>());
+            await _mockAzure.ResourceGroups.DidNotReceive().BeginDeleteByNameAsync(Arg.Any<string>());
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Pinja.AzureSubscriptionCleaner.AzureFunctions.Tests
 
             await _cleaner.DeleteIfNotLocked(ExpectedGroup);
 
-            await _mockAzure.ResourceGroups.Received().DeleteByNameAsync(ExpectedGroup);
+            await _mockAzure.ResourceGroups.Received().BeginDeleteByNameAsync(ExpectedGroup);
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace Pinja.AzureSubscriptionCleaner.AzureFunctions.Tests
 
             await _cleaner.DeleteIfNotLocked(ExpectedGroup);
 
-            await _mockAzure.ResourceGroups.Received().DeleteByNameAsync(ExpectedGroup);
+            await _mockAzure.ResourceGroups.Received().BeginDeleteByNameAsync(ExpectedGroup);
         }
 
         private class MockTimerSchedule : TimerSchedule
@@ -146,7 +146,7 @@ namespace Pinja.AzureSubscriptionCleaner.AzureFunctions.Tests
 
             public Task<IPagedCollection<T>> GetNextPageAsync(CancellationToken cancellationToken = default)
             {
-                throw new System.NotImplementedException();
+                throw new NotImplementedException();
             }
         }
     }

--- a/src/Pinja.AzureSubscriptionCleaner.AzureFunctions/SubscriptionCleaner.cs
+++ b/src/Pinja.AzureSubscriptionCleaner.AzureFunctions/SubscriptionCleaner.cs
@@ -117,7 +117,12 @@ namespace Pinja.AzureSubscriptionCleaner.AzureFunctions
             {
                 try
                 {
-                    await _azureConnection.ResourceGroups.DeleteByNameAsync(name).ConfigureAwait(true);
+                    /*
+                        BeginDeleteByNameAsync is used instead of DeleteByNameAsync because we don't want to wait for operation completion.
+                        This may hide errors if deleting fails, but deleting may take longer than 5 minutes (activity function timeout)
+                        so we do this to avoid timeout.
+                    */
+                    await _azureConnection.ResourceGroups.BeginDeleteByNameAsync(name).ConfigureAwait(true);
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
Deleting a resource group may take a surprisingly long time so instead of waiting for the operation to complete we just do a "fire & forget" approach.

Fixes issue #203 